### PR TITLE
Upgrade dokuwiki to 20230404

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -54,7 +54,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.authorizations=traefik@any:routeadm" \
-    --label="org.nethserver.images=docker.io/bitnami/dokuwiki:20200729.0.0-debian-10-r299" \
+    --label="org.nethserver.images=docker.io/bitnami/dokuwiki:20230404.1.0-debian-11-r77" \
     "${container}"
 # Commit everything
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/systemd/user/dokuwiki.service
+++ b/imageroot/systemd/user/dokuwiki.service
@@ -16,7 +16,7 @@ Restart=always
 ExecStartPre=/bin/rm -f %t/dokuwiki.pid %t/dokuwiki.ctr-id
 # Podman should bind only to 127.0.0.1:TCP_PORT
 # Data are persistend inside dokuwiki-data volume
-ExecStart=/usr/bin/podman run --conmon-pidfile %t/dokuwiki.pid --cidfile %t/dokuwiki.ctr-id --cgroups=no-conmon --replace --name dokuwiki -d --env-file=%S/state/environment -p 127.0.0.1:${TCP_PORT}:8080 -v dokuwiki-data:/bitnami/dokuwiki ${DOKUWIKI_IMAGE}
+ExecStart=/usr/bin/podman run --conmon-pidfile %t/dokuwiki.pid --cidfile %t/dokuwiki.ctr-id --cgroups=no-conmon --replace --name dokuwiki -d --env-file=%S/state/environment -p 127.0.0.1:${TCP_PORT}:8080 -v dokuwiki-data:/bitnami/dokuwiki:z ${DOKUWIKI_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/dokuwiki.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/dokuwiki.ctr-id
 PIDFile=%t/dokuwiki.pid

--- a/imageroot/update-module.d/10Do_upgrades
+++ b/imageroot/update-module.d/10Do_upgrades
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+
+# we need to create a log folder for the upgrade to 20230404
+/usr/bin/podman run -d --rm --name dokuwiki_upgrade -v dokuwiki-data:/bitnami/dokuwiki:z ${DOKUWIKI_IMAGE}
+/usr/bin/podman exec -ti dokuwiki_upgrade mkdir -vp /bitnami/dokuwiki/data/log
+/usr/bin/podman stop dokuwiki_upgrade

--- a/imageroot/update-module.d/80restart_services
+++ b/imageroot/update-module.d/80restart_services
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+
+systemctl --user try-restart dokuwiki.service


### PR DESCRIPTION
Upgrade to 20230404
create the structure to restart on a module update
add a fix specific to the upgrade from the old dokuwiki 20200729 to 20230404