### PR TITLE
add traefik configuration to clone-module

### DIFF
--- a/imageroot/actions/clone-module/50traefik
+++ b/imageroot/actions/clone-module/50traefik
@@ -1,0 +1,1 @@
+../restore-module/50traefik


### PR DESCRIPTION
Clone module is broken because the traefik configuration is not done during the clone-module action 

hence once cloned, the module is not reachable