### PR TITLE
Update hostname format validation and add host field validation messages

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -49,7 +49,8 @@
     "host": {
       "type": "string",
       "description": "Host name for the wiki, like 'wiki.nethserver.org'",
-      "format": "idn-hostname"
+      "format": "hostname",
+      "pattern": "\\."
     },
     "lets_encrypt": {
       "type": "boolean",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -39,7 +39,9 @@
     "disabled": "Disabled",
     "instance_configuration": "Configure {instance}",
     "configuring": "Configuring...",
-    "email_format": "Invalid email address"
+    "email_format": "Invalid email address",
+    "host_pattern": "Must be a valid fully qualified domain name",
+    "host_format": "Must be a valid fully qualified domain name"
   },
   "about": {
     "title": "About"


### PR DESCRIPTION
This pull request updates the hostname format validation in the `validate-input.json` file to use the `hostname` format and adds validation messages for the host field in the `translation.json` file.

Add validation messages for host fields