### PR TITLE
Fix UI of dokuwiki (hostname and first configuration only)

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -49,7 +49,8 @@
     "host": {
       "type": "string",
       "description": "Host name for the wiki, like 'wiki.nethserver.org'",
-      "format": "idn-hostname"
+      "format": "hostname",
+      "pattern": "\\."
     },
     "lets_encrypt": {
       "type": "boolean",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -41,7 +41,7 @@
     "instance_configuration": "Configure {instance}",
     "configuring": "Configuring...",
     "dokuwiki_note": "Note",
-    "must_be_configured_inside_dokuwiki": "You can configure only Dokuwiki FQDN in this page. To configure other setting go to dokuwiki",
+    "must_be_configured_inside_dokuwiki": "You can configure only Dokuwiki FQDN in this page. To configure other setting go to Dokuwiki webapp",
     "go_to_dokuwiki": "Go to Dokuwiki",
     "email_format": "Invalid email address"
   },

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -40,8 +40,9 @@
     "disabled": "Disabled",
     "instance_configuration": "Configure {instance}",
     "configuring": "Configuring...",
-    "cannot_be_configured_again": "This instance cannot be configured anymore here",
-    "must_be_configured_inside_dokuwiki": "The admin user and settings must be configured inside DokuWiki",
+    "dokuwiki_note": "Note",
+    "must_be_configured_inside_dokuwiki": "You can configure only Dokuwiki FQDN in this page. To configure other setting go to dokuwiki",
+    "go_to_dokuwiki": "Go to Dokuwiki",
     "email_format": "Invalid email address"
   },
   "about": {

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -40,6 +40,8 @@
     "disabled": "Disabled",
     "instance_configuration": "Configure {instance}",
     "configuring": "Configuring...",
+    "cannot_be_configured_again": "This instance cannot be configured anymore here",
+    "must_be_configured_inside_dokuwiki": "The admin user and settings must be configured inside DokuWiki",
     "email_format": "Invalid email address"
   },
   "about": {

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -30,6 +30,7 @@
     "admin_email": "Administrator email address",
     "admin_full_name": "Administrator full name",
     "wiki_fqdn": "Wiki FQDN",
+    "host_pattern": "Must be a valid fully qualified domain name",
     "show_password": "Show password",
     "hide_password": "Hide password",
     "save": "Save",

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -19,9 +19,11 @@
       <div class="bx--col">
         <NsInlineNotification
           kind="info"
-          :title="$t('settings.cannot_be_configured_again')"
+          :title="$t('settings.dokuwiki_note')"
           :description="$t('settings.must_be_configured_inside_dokuwiki')"
           :showCloseButton="false"
+          @click="goToDokuwikiWebapp"
+          :actionLabel="$t('settings.go_to_dokuwiki')"
         />
       </div>
     </div>
@@ -206,6 +208,9 @@ export default {
     next();
   },
   methods: {
+    goToDokuwikiWebapp() {
+      window.open(`https://${this.host}`, "_blank");
+    },
     async getConfiguration() {
       this.loading.getConfiguration = true;
       this.error.getConfiguration = "";

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -24,7 +24,7 @@
               v-model.trim="wikiName"
               class="mg-bottom"
               :invalid-message="$t(error.wiki_name)"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || already_set"
               ref="wikiName"
             >
             </cv-text-input>
@@ -33,7 +33,7 @@
               v-model.trim="username"
               class="mg-bottom"
               :invalid-message="$t(error.username)"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || already_set"
               ref="username"
             >
             </cv-text-input>
@@ -45,7 +45,7 @@
               :password-hide-label="$t('settings.hide_password')"
               class="mg-bottom"
               :invalid-message="$t(error.password)"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || already_set"
               ref="password"
             >
             </cv-text-input>
@@ -55,7 +55,7 @@
               v-model.trim="email"
               class="mg-bottom"
               :invalid-message="$t(error.email)"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || already_set"
               ref="email"
             >
             </cv-text-input>
@@ -64,7 +64,7 @@
               v-model.trim="userFullName"
               class="mg-bottom"
               :invalid-message="$t(error.user_full_name)"
-              :disabled="loading.getConfiguration || loading.configureModule"
+              :disabled="loading.getConfiguration || loading.configureModule || already_set"
               ref="userFullName"
             >
             </cv-text-input>
@@ -152,6 +152,7 @@ export default {
         page: "settings",
       },
       urlCheckInterval: null,
+      already_set: false,
       wikiName: "",
       username: "",
       password: "",
@@ -248,6 +249,17 @@ export default {
       this.isLetsEncryptEnabled = config.lets_encrypt;
       this.isHttpToHttpsEnabled = config.http2https;
       this.loading.getConfiguration = false;
+      // set already_set to true if the configuration is not empty
+      if (
+        this.wikiName &&
+        this.username &&
+        this.password &&
+        this.userFullName &&
+        this.email
+      ) {
+        this.already_set = true;
+      }
+
       this.focusElement("wikiName");
     },
     validateConfigureModule() {

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -15,6 +15,16 @@
         />
       </div>
     </div>
+    <div v-if="already_set" class="bx--row">
+      <div class="bx--col">
+        <NsInlineNotification
+          kind="info"
+          :title="$t('settings.cannot_be_configured_again')"
+          :description="$t('settings.must_be_configured_inside_dokuwiki')"
+          :showCloseButton="false"
+        />
+      </div>
+    </div>
     <div class="bx--row">
       <div class="bx--col-lg-16">
         <cv-tile :light="true">


### PR DESCRIPTION
This pull request fix the hostname, we must require a true FQDN (mainly for lets encrypt)

https://community.nethserver.org/t/ns8-dokuwiki-wiki-fqdn-validation/23114

This PR fix the first configuration only issue of dokuwiki, the container reads the env variables just once at the first boot of the container and write the configuration files, even if you modify the environment variables,they are not not used

The fix is to display a banner to inform what to do and disable all the fields

![image](https://github.com/NethServer/ns8-dokuwiki/assets/3164851/c0f1c5ed-6f0b-416b-8170-81a65de17c72)

https://community.nethserver.org/t/ns8-dokuwiki-instance-settings-applied-only-the-first-time/23104


refs: https://github.com/NethServer/dev/issues/6894