### PR TITLE
Use groups instead of users in write-ldap-conf

### DIFF
--- a/imageroot/bin/write-ldap-conf
+++ b/imageroot/bin/write-ldap-conf
@@ -57,7 +57,7 @@ EOF
 fi
 cat <<EOF >> dokuwiki-config/local.protected.php
 \$conf['useacl'] = 1;
-\$conf['superuser'] = 'admin,admin@${LDAP_DOMAIN},administrator,administrator@${LDAP_DOMAIN}';
+\$conf['superuser'] = '@admin,@domain\ admins';
 EOF
 
 echo "Configuration written to dokuwiki-config/local.protected.php"


### PR DESCRIPTION
Set 

`\$conf['superuser'] = '@admin,@domain\ admins';`

in DokuWiki config to allow internal admins and domain admins by group instead of just the users named admin/administrator.

Nethserver/dev#6919