### PR TITLE
Fix typo in LDAP superuser group name for admin domains

### DIFF
--- a/imageroot/bin/write-ldap-conf
+++ b/imageroot/bin/write-ldap-conf
@@ -57,7 +57,7 @@ EOF
 fi
 cat <<EOF >> dokuwiki-config/local.protected.php
 \$conf['useacl'] = 1;
-\$conf['superuser'] = '@admin,@domain\ admins';
+\$conf['superuser'] = '@admin,@domain admins';
 EOF
 
 echo "Configuration written to dokuwiki-config/local.protected.php"


### PR DESCRIPTION
The escape chars prevents to allow the admin right, we cannot see the admin menu in the upper right  corner

https://github.com/NethServer/dev/issues/6919