### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -14,7 +14,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://www.dokuwiki.org/dokuwiki",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/dokuwiki.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-dokuwiki"
   },


### PR DESCRIPTION
This pull request updates the `documentation_url` in the `ui/public/metadata.json` file to point to the latest and more specific documentation for the project.

* [`ui/public/metadata.json`](diffhunk://#diff-57394ba6289dada95fe587665ef1b86264521bc888ccdaa69d5994e96f1ea77dL17-R17): Updated the `documentation_url` from "https://www.dokuwiki.org/dokuwiki" to "https://docs.nethserver.org/projects/ns8/en/latest/dokuwiki.html" to ensure users are directed to the correct and most relevant documentation.

https://github.com/NethServer/dev/issues/7399