### PR TITLE
Change Dokuwiki Upstream Image Source to Official Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ The above command will:
 - start and configure the Dokuwiki instance
 - configure a virtual host for trafik to access the instance
 
+## PHP settings
+
+you can modify in the environment file some PHP settings, you need to restart the container after the modification
+
+```
+PHP_MEMORYLIMIT=512M
+PHP_TIMEZONE=UTC
+PHP_UPLOADLIMIT=256M
+```
+
 ## Uninstall
 
 To uninstall the instance and remove traefik virtual host:

--- a/build-images.sh
+++ b/build-images.sh
@@ -54,7 +54,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.authorizations=traefik@any:routeadm cluster:accountconsumer" \
-    --label="org.nethserver.images=docker.io/bitnami/dokuwiki:20240206-debian-12" \
+    --label="org.nethserver.images=docker.io/dokuwiki/dokuwiki:2024-02-06a" \
     "${container}"
 # Commit everything
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/build-images.sh
+++ b/build-images.sh
@@ -54,7 +54,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=0" \
     --label="org.nethserver.authorizations=traefik@any:routeadm cluster:accountconsumer" \
-    --label="org.nethserver.images=docker.io/dokuwiki/dokuwiki:2024-02-06a" \
+    --label="org.nethserver.images=docker.io/dokuwiki/dokuwiki:2025-05-14a" \
     "${container}"
 # Commit everything
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -63,7 +63,3 @@ agent.set_env("PHP_TIMEZONE", "UTC")
 
 # Setup LDAP domain
 agent.set_env("LDAP_DOMAIN", ldap_domain)
-
-# Make sure everything is saved inside the environment file
-# just before starting systemd unit
-agent.dump_env()

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -57,8 +57,9 @@ agent.set_env("DOKUWIKI_EMAIL", email)
 agent.set_env("DOKUWIKI_FULL_NAME", full_name)
 
 # Setup PHP with safe defaults
-agent.set_env("PHP_ENABLE_OPCACHE", "1")
-agent.set_env("PHP_MEMORY_LIMIT", "512M")
+agent.set_env("PHP_MEMORYLIMIT", "512M")
+agent.set_env("PHP_UPLOADLIMIT", "256M")
+agent.set_env("PHP_TIMEZONE", "UTC")
 
 # Setup LDAP domain
 agent.set_env("LDAP_DOMAIN", ldap_domain)

--- a/imageroot/actions/configure-module/30traefik
+++ b/imageroot/actions/configure-module/30traefik
@@ -43,10 +43,6 @@ agent.set_env("TRAEFIK_HOST", host)
 agent.set_env("TRAEFIK_HTTP2HTTPS", h2hs)
 agent.set_env("TRAEFIK_LETS_ENCRYPT", le)
 
-# Make sure everything is saved inside the environment file
-# just before starting systemd unit
-agent.dump_env()
-
 # Find default traefik instance for current node
 default_traefik_id = agent.resolve_agent_id('traefik@node')
 if default_traefik_id is None:

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -42,5 +42,3 @@ for evar in [
         "TRAEFIK_LETS_ENCRYPT",
     ]:
     agent.set_env(evar, original_environment[evar])
-
-agent.dump_env()

--- a/imageroot/bin/push-configuration
+++ b/imageroot/bin/push-configuration
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+set -e 
+
 if ! podman exec dokuwiki ls /storage/conf/local.php >/dev/null 2>&1; then
     echo "We init the first configuration of Dokuwiki by the install PHP script"
     curl -s -o /dev/null -X POST "http://127.0.0.1:${TCP_PORT}/install.php" \

--- a/imageroot/bin/push-configuration
+++ b/imageroot/bin/push-configuration
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+if ! podman exec dokuwiki ls /storage/conf/local.php >/dev/null 2>&1; then
+    echo "We init the first configuration of Dokuwiki by the install PHP script"
+    curl -s -o /dev/null -X POST "http://127.0.0.1:${TCP_PORT}/install.php" \
+        -d "d[title]=${DOKUWIKI_WIKI_NAME}" \
+        -d "d[acl]=1" \
+        -d "d[superuser]=${DOKUWIKI_USERNAME}" \
+        -d "d[fullname]=${DOKUWIKI_FULL_NAME}" \
+        -d "d[email]=${DOKUWIKI_EMAIL}" \
+        -d "d[password]=${DOKUWIKI_PASSWORD}" \
+        -d "d[confirm]=${DOKUWIKI_PASSWORD}" \
+        -d "d[policy]=1" \
+        -d "d[allowreg]=0" \
+        -d "d[license]=" \
+        -d "d[pop]=0" \
+        -d "submit=1"
+fi
+
+echo "We push the authentication files."
+podman cp ./dokuwiki-config/. dokuwiki:/storage/conf/

--- a/imageroot/bin/wait-after-boot
+++ b/imageroot/bin/wait-after-boot
@@ -9,8 +9,8 @@
 
 count=0
 while [[ $count -lt 60 ]]; do
-    if podman exec -ti dokuwiki ls /bitnami/dokuwiki/conf/local.php.dist >/dev/null 2>&1; then
-        echo "First Configuration done. We push custom configuration files."
+    if podman exec dokuwiki ls /storage/conf/license.php >/dev/null 2>&1; then
+        echo "Dokuwiki container is ready."
         exit 0
     fi
     ((count++))

--- a/imageroot/bin/wait-after-boot
+++ b/imageroot/bin/wait-after-boot
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+set -e 
+
 # specific to dokuwiki, it creates its own configuration file after a long time boot 
 
 count=0

--- a/imageroot/bin/write-ldap-conf
+++ b/imageroot/bin/write-ldap-conf
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+set -e 
+
 # Retrieving environment variables
 LDAP_DOMAIN=${LDAP_DOMAIN}
 LDAP_PORT=${LDAP_PORT}

--- a/imageroot/systemd/user/dokuwiki.service
+++ b/imageroot/systemd/user/dokuwiki.service
@@ -25,8 +25,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/dokuwiki.pid \
     --replace --name dokuwiki -d \
     --env-file=%S/state/environment \
     --publish 127.0.0.1:${TCP_PORT}:8080 \
-    --user 1001:0 \
-    --volume dokuwiki-data:/storage:U \
+    --volume dokuwiki-data:/storage:z \
     --network=slirp4netns:allow_host_loopback=true \
     --add-host=accountprovider:10.0.2.2 \
     ${DOKUWIKI_IMAGE}

--- a/imageroot/systemd/user/dokuwiki.service
+++ b/imageroot/systemd/user/dokuwiki.service
@@ -25,7 +25,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/dokuwiki.pid \
     --replace --name dokuwiki -d \
     --env-file=%S/state/environment \
     --publish 127.0.0.1:${TCP_PORT}:8080 \
-    --volume dokuwiki-data:/bitnami/dokuwiki:z \
+    --volume dokuwiki-data:/storage:z \
     --network=slirp4netns:allow_host_loopback=true \
     --add-host=accountprovider:10.0.2.2 \
     ${DOKUWIKI_IMAGE}

--- a/imageroot/systemd/user/dokuwiki.service
+++ b/imageroot/systemd/user/dokuwiki.service
@@ -25,13 +25,13 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/dokuwiki.pid \
     --replace --name dokuwiki -d \
     --env-file=%S/state/environment \
     --publish 127.0.0.1:${TCP_PORT}:8080 \
-    --volume dokuwiki-data:/storage:z \
+    --user 1001:0 \
+    --volume dokuwiki-data:/storage:U \
     --network=slirp4netns:allow_host_loopback=true \
     --add-host=accountprovider:10.0.2.2 \
     ${DOKUWIKI_IMAGE}
 ExecStartPost=/usr/local/bin/runagent wait-after-boot
-ExecStartPost=podman cp ./dokuwiki-config/local.protected.php dokuwiki:/bitnami/dokuwiki/conf/local.protected.php
-ExecStartPost=podman cp ./dokuwiki-config/plugins.local.php dokuwiki:/bitnami/dokuwiki/conf/plugins.local.php
+ExecStartPost=/usr/local/bin/runagent push-configuration
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/dokuwiki.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/dokuwiki.ctr-id
 PIDFile=%t/dokuwiki.pid


### PR DESCRIPTION
Replace the Bitnami Dokuwiki container image with the official Dokuwiki image in ns8-dokuwiki. Address migration issues, such as file permissions and configuration compatibility

https://github.com/NethServer/dev/issues/7514