### PR TITLE
Refactor Dokuwiki configuration to use secrets.env

### DIFF
--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -52,7 +52,6 @@ else:
 # Setup configuration from user input.
 agent.set_env("DOKUWIKI_WIKI_NAME", wiki_name)
 agent.set_env("DOKUWIKI_USERNAME", username)
-agent.set_env("DOKUWIKI_PASSWORD", password)
 agent.set_env("DOKUWIKI_EMAIL", email)
 agent.set_env("DOKUWIKI_FULL_NAME", full_name)
 
@@ -63,3 +62,9 @@ agent.set_env("PHP_TIMEZONE", "UTC")
 
 # Setup LDAP domain
 agent.set_env("LDAP_DOMAIN", ldap_domain)
+
+# setup dokuwiki password
+secrets_env = {
+    "DOKUWIKI_PASSWORD": password,
+}
+agent.write_envfile("secrets.env", secrets_env)

--- a/imageroot/actions/create-module/05secrets.env
+++ b/imageroot/actions/create-module/05secrets.env
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-#
-# Copyright (C) 2025 Nethesis S.r.l.
-# SPDX-License-Identifier: GPL-3.0-or-later
-#
-
-touch secrets.env

--- a/imageroot/actions/create-module/05secrets.env
+++ b/imageroot/actions/create-module/05secrets.env
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+touch secrets.env

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -38,7 +38,10 @@ env = f'module/{os.environ["MODULE_ID"]}/environment'
 rdb = agent.redis_connect()
 config["wiki_name"] = rdb.hget(env, "DOKUWIKI_WIKI_NAME")
 config["username"] = rdb.hget(env, "DOKUWIKI_USERNAME");
-config["password"] = rdb.hget(env, "DOKUWIKI_PASSWORD"); 
+
+secrets = agent.read_envfile("secrets.env")
+config["password"] = secrets["DOKUWIKI_PASSWORD"]
+
 config["email"] = rdb.hget(env, "DOKUWIKI_EMAIL");
 config["user_full_name"] = rdb.hget(env, "DOKUWIKI_FULL_NAME");
 config["host"] =  rdb.hget(env, "TRAEFIK_HOST");

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -35,18 +35,17 @@ config = {}
 
 # Read current configuration from Redis
 env = f'module/{os.environ["MODULE_ID"]}/environment'
-rdb = agent.redis_connect()
-config["wiki_name"] = rdb.hget(env, "DOKUWIKI_WIKI_NAME")
-config["username"] = rdb.hget(env, "DOKUWIKI_USERNAME");
+config["wiki_name"] = os.getenv("DOKUWIKI_WIKI_NAME")
+config["username"] = os.getenv("DOKUWIKI_USERNAME");
 
 secrets = agent.read_envfile("secrets.env")
 config["password"] = secrets["DOKUWIKI_PASSWORD"]
 
-config["email"] = rdb.hget(env, "DOKUWIKI_EMAIL");
-config["user_full_name"] = rdb.hget(env, "DOKUWIKI_FULL_NAME");
-config["host"] =  rdb.hget(env, "TRAEFIK_HOST");
-config["http2https"] =  rdb.hget(env, "TRAEFIK_HTTP2HTTPS") == "True";
-config["lets_encrypt"] =  rdb.hget(env, "TRAEFIK_LETS_ENCRYPT") == "True";
+config["email"] = os.getenv("DOKUWIKI_EMAIL");
+config["user_full_name"] = os.getenv("DOKUWIKI_FULL_NAME");
+config["host"] =  os.getenv("TRAEFIK_HOST");
+config["http2https"] =  os.getenv("TRAEFIK_HTTP2HTTPS") == "True";
+config["lets_encrypt"] =  os.getenv("TRAEFIK_LETS_ENCRYPT") == "True";
 # retrieve LDAP domains list
 lp = Ldapproxy()
 domains = []

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -38,8 +38,7 @@ env = f'module/{os.environ["MODULE_ID"]}/environment'
 config["wiki_name"] = os.getenv("DOKUWIKI_WIKI_NAME")
 config["username"] = os.getenv("DOKUWIKI_USERNAME");
 
-secrets = agent.read_envfile("secrets.env")
-config["password"] = secrets.get("DOKUWIKI_PASSWORD")
+config["password"] = agent.read_envfile("secrets.env")["DOKUWIKI_PASSWORD"] if os.path.exists("secrets.env") else None
 
 config["email"] = os.getenv("DOKUWIKI_EMAIL");
 config["user_full_name"] = os.getenv("DOKUWIKI_FULL_NAME");

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -39,7 +39,7 @@ config["wiki_name"] = os.getenv("DOKUWIKI_WIKI_NAME")
 config["username"] = os.getenv("DOKUWIKI_USERNAME");
 
 secrets = agent.read_envfile("secrets.env")
-config["password"] = secrets["DOKUWIKI_PASSWORD"]
+config["password"] = secrets.get("DOKUWIKI_PASSWORD")
 
 config["email"] = os.getenv("DOKUWIKI_EMAIL");
 config["user_full_name"] = os.getenv("DOKUWIKI_FULL_NAME");

--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -32,7 +32,6 @@ for evar in [
         "DOKUWIKI_EMAIL",
         "DOKUWIKI_FULL_NAME",
         "DOKUWIKI_IMAGE",
-        "DOKUWIKI_PASSWORD",
         "DOKUWIKI_USERNAME",
         "DOKUWIKI_WIKI_NAME",
         "PHP_ENABLE_OPCACHE",

--- a/imageroot/bin/push-configuration
+++ b/imageroot/bin/push-configuration
@@ -7,9 +7,8 @@
 
 set -e 
 
-set -a
-source ./secrets.env
-set +a
+# Load environment variables, if available and protect against shell special chars.
+DOKUWIKI_PASSWORD=$(grep '^DOKUWIKI_PASSWORD=' ./secrets.env) && export "${DOKUWIKI_PASSWORD?}"
 
 if ! podman exec dokuwiki ls /storage/conf/local.php >/dev/null 2>&1; then
     echo "We init the first configuration of Dokuwiki by the install PHP script"

--- a/imageroot/bin/push-configuration
+++ b/imageroot/bin/push-configuration
@@ -7,6 +7,10 @@
 
 set -e 
 
+set -a
+source ./secrets.env
+set +a
+
 if ! podman exec dokuwiki ls /storage/conf/local.php >/dev/null 2>&1; then
     echo "We init the first configuration of Dokuwiki by the install PHP script"
     curl -s -o /dev/null -X POST "http://127.0.0.1:${TCP_PORT}/install.php" \

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -4,3 +4,4 @@
 # Restic --files-from: https://restic.readthedocs.io/en/stable/040_backup.html#including-files
 #
 volumes/dokuwiki-data
+state/secrets.env

--- a/imageroot/update-module.d/10Do_upgrades
+++ b/imageroot/update-module.d/10Do_upgrades
@@ -1,15 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 #
-# Copyright (C) 2023 Nethesis S.r.l.
+# Copyright (C) 2025 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
+import os
+import agent
 
-exec 1>&2
-
-# we need to create a log folder for the upgrade to 20230404
-if [[ "$PREV_DOKUWIKI_IMAGE" == "docker.io/bitnami/dokuwiki:20200729.0.0-debian-10-r299" ]]; then
-    /usr/bin/podman run -d --rm --name dokuwiki_upgrade -v dokuwiki-data:/bitnami/dokuwiki:z ${DOKUWIKI_IMAGE}
-    /usr/bin/podman exec -ti dokuwiki_upgrade mkdir -vp /bitnami/dokuwiki/data/log
-    /usr/bin/podman stop dokuwiki_upgrade
-fi
+# test if the secrets.env is not present
+if not os.path.exists("secrets.env"):
+    # if not present, create it
+    passwords = {
+        "DOKUWIKI_PASSWORD": os.environ["DOKUWIKI_PASSWORD"],
+    }
+    agent.write_envfile("secrets.env", passwords)
+    agent.unset_env("DOKUWIKI_PASSWORD")


### PR DESCRIPTION
Migrate Dokuwiki password management from Redis to a dedicated `secrets.env` file for improved security and organization. Initialize environment variables from this file in the configuration scripts and ensure it is included in backup patterns. Convert the upgrade script to Python and create the `secrets.env` file if it does not exist.

https://github.com/NethServer/dev/issues/7514