### PR TITLE
Remove bitnami branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dokuwiki
 
 Start and configure a Dokuwiki instance.
-The module uses [Bitnami DokuWiki image](https://github.com/bitnami/bitnami-docker-dokuwiki).
+The module uses [DokuWiki image](https://hub.docker.com/r/dokuwiki/dokuwiki).
 
 ## Install
 


### PR DESCRIPTION
This pull request updates the documentation to reflect a change in the Docker image used for the Dokuwiki module.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4): Updated the link to the Docker image from the Bitnami DokuWiki image to the official DokuWiki image on Docker Hub.